### PR TITLE
Use hashlib if xxhash is not available.

### DIFF
--- a/src/dsc_parser.py
+++ b/src/dsc_parser.py
@@ -9,7 +9,10 @@ This file defines methods to load and preprocess DSC scripts
 
 import os, re, itertools, copy, platform, glob, yaml
 from collections import Mapping, OrderedDict, Counter
-from xxhash import xxh32 as xxh
+try:
+    from xxhash import xxh32 as xxh
+expect:
+    from hashlib import md5 as xxh
 from sos.utils import env
 from sos.targets import fileMD5, executable
 from .utils import FormatError, strip_dict, find_nested_key, recursive_items, merge_lists, flatten_list, uniq_list, \

--- a/src/dsc_translator.py
+++ b/src/dsc_translator.py
@@ -7,7 +7,10 @@ __license__ = "MIT"
 This file defines methods to translate DSC into pipeline in SoS language
 '''
 import os, sys, msgpack, glob, inspect
-from xxhash import xxh32 as xxh
+try:
+    from xxhash import xxh32 as xxh
+expect ImportError:
+    from hashlib import md5 as xxh
 from collections import OrderedDict
 from sos.targets import path
 from .utils import uniq_list, dict2str, n2a, empty_log, remove_log, \

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,10 @@ import sys, os, re, yaml, itertools, collections, sympy
 from itertools import cycle, chain, islice
 from fnmatch import fnmatch
 from difflib import SequenceMatcher
-from xxhash import xxh32 as xxh
+try:
+    from xxhash import xxh32 as xxh
+expect:
+    from hashlib import md5 as xxh
 from .constant import HTML_CSS, HTML_JS
 
 class Logger:


### PR DESCRIPTION
SoS does not install xxhash if the platform is win32 ([source](https://github.com/vatlab/SoS/blob/master/setup.py#L207)). Since xxhash may not be available, it provides a fallback option from hashlib ([source](https://github.com/vatlab/SoS/blob/master/src/sos/targets.py#L25)):

```
try:
    from xxhash import xxh64 as hash_md5
except ImportError:
    from hashlib import md5 as hash_md5
```

In this PR, I started to implement a similar solution for DSC, in case a user installs it on a win32 machine.

@gaow Thoughts on this? Can `hashlib.md5()` safely replace the functionality of `xxhash.xxh32()` as used by DSC?
