### PR TITLE
Test installation on Linux via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "3.6"
+install:
+  - pip install -r requirements.txt
+script:
+  - python -m pip install . --no-deps -vv
+  - dsc --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "3.6"
 install:
-  - pip install -r requirements.txt
+  - pip install --ignore-installed -r requirements.txt
 script:
   - python -m pip install . --no-deps -vv
   - dsc --help

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-LICENSE.txt
+include LICENSE.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+h5py
+msgpack-python
+numexpr
+numpy
+pandas>=0.23.4
+PTable
+pyarrow>=0.5.0
+sos>=0.17.4
+sos-pbs>=0.9.17.0
+sqlalchemy
+sympy
+tzlocal

--- a/src/dsc_parser.py
+++ b/src/dsc_parser.py
@@ -11,7 +11,7 @@ import os, re, itertools, copy, platform, glob, yaml
 from collections import Mapping, OrderedDict, Counter
 try:
     from xxhash import xxh32 as xxh
-expect:
+except ImportError:
     from hashlib import md5 as xxh
 from sos.utils import env
 from sos.targets import fileMD5, executable

--- a/src/dsc_translator.py
+++ b/src/dsc_translator.py
@@ -9,7 +9,7 @@ This file defines methods to translate DSC into pipeline in SoS language
 import os, sys, msgpack, glob, inspect
 try:
     from xxhash import xxh32 as xxh
-expect ImportError:
+except ImportError:
     from hashlib import md5 as xxh
 from collections import OrderedDict
 from sos.targets import path

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,7 +10,7 @@ from fnmatch import fnmatch
 from difflib import SequenceMatcher
 try:
     from xxhash import xxh32 as xxh
-expect:
+except ImportError:
     from hashlib import md5 as xxh
 from .constant import HTML_CSS, HTML_JS
 


### PR DESCRIPTION
I'm glad I set this up. Both of my previous PRs contained mistakes!

xref: #156, #157 

Note that I only build on 3.6 because the Travis docs currently have a [warning](https://docs.travis-ci.com/user/languages/python/#development-releases-support) about using 3.7 and 3.7-dev:

> Recent Python branches require OpenSSL 1.0.2+. As this library is not available for Trusty, 3.7, 3.7-dev, 3.8-dev, and nightly do not work (or use outdated archive).