### PR TITLE
Option `others =` in `dscrquery`

### DIFF
--- a/dscrutils/R/dscquery.R
+++ b/dscrutils/R/dscquery.R
@@ -15,6 +15,11 @@
 #' one can specify multiple properties from the same module.
 #' These will be the names of the columns in the returned data frame.
 #'
+#' @param others Additional query items similarly specified as \code{targets}.
+#' Difference between \code{targets} and `\code{others}` is that the rows 
+#' whose \code{targets} columns containing all missing values will be removed, while
+#' \code{others} columns will not have this impact. 
+#'
 #' @param conditions The default \code{NULL} means "no conditions", in
 #' which case the results for all DSC pipelines are returned. 
 #' Query conditions are specified as R expression ... !FIXME!
@@ -109,8 +114,9 @@
 #'
 #' @export
 #'
-dscquery <- function (dsc.outdir, targets, conditions = NULL, groups = NULL,
-                      add.path = FALSE, omit.file.columns = FALSE, exec = "dsc-query",
+dscquery <- function (dsc.outdir, targets, others = NULL, conditions = NULL, 
+                      groups = NULL, add.path = FALSE, 
+                      omit.file.columns = FALSE, exec = "dsc-query",
                       max.extract.vector = 10, verbose = TRUE, cores = NULL) {
 
   # CHECK INPUTS
@@ -121,7 +127,12 @@ dscquery <- function (dsc.outdir, targets, conditions = NULL, groups = NULL,
 
   # Check input argument "targets".
   if (!(is.character(targets) & is.vector(targets) & !is.list(targets)))
-    stop("Argument \"targets\" should be a character vector")
+    stop("Argument \"targets\" should be a character string or vector")
+
+  # Check input argument "others".
+  if (!is.null(others))
+    if (!(is.character(others) & is.vector(others) & !is.list(others)))
+      stop("Argument \"others\" should be a character string or vector")
 
   # Check input argument "conditions".
   if (!is.null(conditions))

--- a/dscrutils/R/dscquery.R
+++ b/dscrutils/R/dscquery.R
@@ -7,8 +7,8 @@
 #'
 #' @param dsc.outdir Directory where DSC output is stored.
 #'
-#' @param targets Query targets specified as a character vector, or,
-#' character string separated by space, e.g.,
+#' @param targets Query targets specified as
+#' character string separated by space, or a character vector, e.g.,
 #' \code{targets = "simulate.n analyze score.error"} and
 #' \code{targets = c("simulate.n","analyze","score.error")} are equivalent.
 #' Using \code{paste}, eg \code{paste("simulate",c("n","p","df"),sep=".")}
@@ -16,15 +16,19 @@
 #' These will be the names of the columns in the returned data frame.
 #'
 #' @param conditions The default \code{NULL} means "no conditions", in
-#' which case the results for all DSC pipelines are returned.
+#' which case the results for all DSC pipelines are returned. 
+#' Query conditions are specified as R expression ... !FIXME!
 #'
 #' @param groups Definition of module groups. For example,
 #' \code{groups = c("method: mean, median", "score: abs_err, sqrt_err")}
 #' will dynamically create module groups \code{method} and \code{score}
 #' even if they have not previously been defined when running DSC.
 #'
-#' @param add.path If TRUE, the returned data frame will contain full
-#' pathnames, not just the base filenames.
+#' @param omit.file.columns If TRUE will remove columns of filenames.
+#' That is, columns ending with "output.file" colnames. 
+#'
+#' @param add.path If TRUE, the returned file column in data frame 
+#' will contain full pathnames, not just the base filenames.
 #'
 #' @param exec The command or pathname of the dsc-query executable.
 #'
@@ -106,7 +110,7 @@
 #' @export
 #'
 dscquery <- function (dsc.outdir, targets, conditions = NULL, groups = NULL,
-                      add.path = FALSE, exec = "dsc-query", load.pkl = FALSE,
+                      add.path = FALSE, omit.file.columns = FALSE, exec = "dsc-query",
                       max.extract.vector = 10, verbose = TRUE, cores = NULL) {
 
   # CHECK INPUTS
@@ -299,5 +303,6 @@ dscquery <- function (dsc.outdir, targets, conditions = NULL, groups = NULL,
   dat.names  <- unlist(lapply(dat,names))
   dat        <- do.call(cbind,dat)
   names(dat) <- dat.names
+  if (omit.file.columns) dat <- dat[, !grepl("output.file", dat.names)]
   return(dat)
 }

--- a/dscrutils/R/dscquery.R
+++ b/dscrutils/R/dscquery.R
@@ -191,8 +191,8 @@ dscquery <- function (dsc.outdir, targets, others = NULL, conditions = NULL,
   # -----------------
   target_cols <- which(gsub(":.*|\\.output\\.file", "", names(dat)) %in% targets)
   # columns indexed by `target_cols` should have at least one non-missing value
-  target_rows <- which(apply(dat[, target_cols],1, function(r) !all(r %in% NA)))
-  dat <- dat[target_rows,]
+  target_rows <- which(apply(dat[, target_cols, drop=FALSE],1, function(r) !all(r %in% NA)))
+  dat <- dat[target_rows, , drop=FALSE]
   # PROCESS THE DSC QUERY RESULT
   # ----------------------------
   # Get the indices of all the columns of the form

--- a/dscrutils/man/dscquery.Rd
+++ b/dscrutils/man/dscquery.Rd
@@ -4,9 +4,10 @@
 \alias{dscquery}
 \title{SQL-like interface for querying DSC output.}
 \usage{
-dscquery(dsc.outdir, targets, conditions = NULL, groups = NULL,
-  add.path = FALSE, omit.file.columns = FALSE, exec = "dsc-query",
-  max.extract.vector = 10, verbose = TRUE, cores = NULL)
+dscquery(dsc.outdir, targets, others = NULL, conditions = NULL,
+  groups = NULL, add.path = FALSE, omit.file.columns = FALSE,
+  exec = "dsc-query", max.extract.vector = 10, verbose = TRUE,
+  cores = NULL)
 }
 \arguments{
 \item{dsc.outdir}{Directory where DSC output is stored.}
@@ -18,6 +19,11 @@ character string separated by space, or a character vector, e.g.,
 Using \code{paste}, eg \code{paste("simulate",c("n","p","df"),sep=".")}
 one can specify multiple properties from the same module.
 These will be the names of the columns in the returned data frame.}
+
+\item{others}{Additional query items similarly specified as \code{targets}.
+Difference between \code{targets} and `\code{others}` is that the rows 
+whose \code{targets} columns containing all missing values will be removed, while
+\code{others} columns will not have this impact.}
 
 \item{conditions}{The default \code{NULL} means "no conditions", in
 which case the results for all DSC pipelines are returned. 

--- a/dscrutils/man/dscquery.Rd
+++ b/dscrutils/man/dscquery.Rd
@@ -5,14 +5,14 @@
 \title{SQL-like interface for querying DSC output.}
 \usage{
 dscquery(dsc.outdir, targets, conditions = NULL, groups = NULL,
-  add.path = FALSE, exec = "dsc-query", load.pkl = FALSE,
+  add.path = FALSE, omit.file.columns = FALSE, exec = "dsc-query",
   max.extract.vector = 10, verbose = TRUE, cores = NULL)
 }
 \arguments{
 \item{dsc.outdir}{Directory where DSC output is stored.}
 
-\item{targets}{Query targets specified as a character vector, or,
-character string separated by space, e.g.,
+\item{targets}{Query targets specified as
+character string separated by space, or a character vector, e.g.,
 \code{targets = "simulate.n analyze score.error"} and
 \code{targets = c("simulate.n","analyze","score.error")} are equivalent.
 Using \code{paste}, eg \code{paste("simulate",c("n","p","df"),sep=".")}
@@ -20,15 +20,19 @@ one can specify multiple properties from the same module.
 These will be the names of the columns in the returned data frame.}
 
 \item{conditions}{The default \code{NULL} means "no conditions", in
-which case the results for all DSC pipelines are returned.}
+which case the results for all DSC pipelines are returned. 
+Query conditions are specified as R expression ... !FIXME!}
 
 \item{groups}{Definition of module groups. For example,
 \code{groups = c("method: mean, median", "score: abs_err, sqrt_err")}
 will dynamically create module groups \code{method} and \code{score}
 even if they have not previously been defined when running DSC.}
 
-\item{add.path}{If TRUE, the returned data frame will contain full
-pathnames, not just the base filenames.}
+\item{add.path}{If TRUE, the returned file column in data frame 
+will contain full pathnames, not just the base filenames.}
+
+\item{omit.file.columns}{If TRUE will remove columns of filenames.
+That is, columns ending with "output.file" colnames.}
 
 \item{exec}{The command or pathname of the dsc-query executable.}
 


### PR DESCRIPTION
Option `others` was added in addition to `targets`. Here is the documentation:

```
 targets: Query targets specified as character string separated by
          space, or a character vector, e.g., ‘targets = "simulate.n
          analyze score.error"’ and ‘targets =
          c("simulate.n","analyze","score.error")’ are equivalent.
          Using ‘paste’, eg ‘paste("simulate",c("n","p","df"),sep=".")’
          one can specify multiple properties from the same module.
          These will be the names of the columns in the returned data
          frame.

  others: Additional query items similarly specified as ‘targets’.
          Difference between ‘targets’ and `‘others’` is that the rows
          whose ‘targets’ columns containing all missing values will be
          removed, while ‘others’ columns will not have this impact.
```