### PR TITLE
Install Python and R with conda on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ install:
   - conda config --set auto_update_conda no
   - conda config --add channels defaults
   - conda config --add channels conda-forge
+  - conda update --all
   - travis_retry conda install --file requirements.txt
-  - conda install r-dplyr r-rlang r-ggplot2 r-shiny r-reticulate r-testthat
+  - conda install r-dplyr r-rlang r-ggplot2 r-shiny r-reticulate r-testthat r-yaml
 
 script:
   - python -m pip install . --no-deps -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
                   r-ggplot2 \
                   r-shiny \
                   r-reticulate \
-                  r-testthat \
+                  r-testthat
 
 script:
   - python -m pip install . --no-deps -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,32 +5,39 @@ python:
   
 dist: xenial
 
-addons:
-  apt:
-    update: true
-    packages:
-      - r-base
-      - r-base-dev
-      - r-cran-yaml
-
 env:
   global:
     - _R_CHECK_FORCE_SUGGESTS_: false
 
 install:
-  - pip install --ignore-installed -r requirements.txt
+  - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.27.1-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes
+  - conda config --set quiet yes
+  - conda config --set changeps1 no
+  - conda config --set auto_update_conda no
+  - conda config --add channels defaults
+  - conda config --add channels conda-forge
+  - travis_retry conda install --file requirements.txt
+  - conda install r-dplyr \
+                  r-rlang \
+                  r-ggplot2 \
+                  r-shiny \
+                  r-reticulate \
+                  r-testthat \
 
 script:
   - python -m pip install . --no-deps -vv
   - dsc --help
   - dsc-query --version
-  - sudo R --slave -e 'options(repos = "https://cran.mtu.edu"); install.packages(c("dplyr","rlang","ggplot2","shiny","reticulate","testthat"),type = "source")'
   - R CMD build --no-manual dscrutils
-  - sudo R CMD INSTALL dscrutils_*.tar.gz
+  - R CMD INSTALL dscrutils_*.tar.gz
   - R CMD check --as-cran --no-manual dscrutils_*.tar.gz
   - cd test && python test_parser.py && python test_query.py
 
 branches:
   only:
     - master
-  
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,7 @@ install:
   - conda config --add channels defaults
   - conda config --add channels conda-forge
   - travis_retry conda install --file requirements.txt
-  - conda install r-dplyr \
-                  r-rlang \
-                  r-ggplot2 \
-                  r-shiny \
-                  r-reticulate \
-                  r-testthat
+  - conda install r-dplyr r-rlang r-ggplot2 r-shiny r-reticulate r-testthat
 
 script:
   - python -m pip install . --no-deps -vv


### PR DESCRIPTION
This avoids the numpy error caused by mixing R installed with APT with Python installed in a virtual environment.

The build passed on my fork: https://travis-ci.org/jdblischak/dsc/builds/526712191