### PR TITLE
Support collections.abc, rpy2 3.5 error with IntVector

### DIFF
--- a/src/dsc_io.py
+++ b/src/dsc_io.py
@@ -92,6 +92,8 @@ def load_rds(filename, types=None):
         else:
             if isinstance(data, RI.NULLType):
                 res = None
+            elif isinstance(data, RV.IntVector):
+                res = np.array(data, dtype=int)
             else:
                 res = data
         if isinstance(res, np.ndarray) and res.shape == (1, ):
@@ -123,7 +125,11 @@ def load_rds(filename, types=None):
 
 
 def save_rds(data, filename):
-    import collections, re
+    import re
+    try:
+        from collections.abc import Mapping
+    except ImportError:
+        from collections import Mapping
     import pandas as pd
     import numpy as np
     import rpy2.robjects as RO
@@ -172,14 +178,14 @@ def save_rds(data, filename):
             k = re.sub(r'[^\w' + '_.' + ']', '_', str(k))
             if k.isdigit():
                 k = str(k)
-            if isinstance(v, collections.Mapping):
+            if isinstance(v, Mapping):
                 assign_dict('%s$%s' % (name, k), v)
             else:
                 assign('item', v)
                 RO.r('%s$%s <- item' % (name, k))
 
     #
-    if isinstance(data, collections.Mapping):
+    if isinstance(data, Mapping):
         assign_dict('res', data)
     else:
         assign('res', data)

--- a/src/dsc_parser.py
+++ b/src/dsc_parser.py
@@ -8,7 +8,11 @@ This file defines methods to load and preprocess DSC scripts
 '''
 
 import os, re, itertools, copy, glob, yaml, warnings, platform
-from collections import Mapping, OrderedDict, Counter
+from collections import OrderedDict, Counter
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 try:
     from xxhash import xxh32 as xxh
 except ImportError:

--- a/src/line.py
+++ b/src/line.py
@@ -12,6 +12,10 @@ from sos.utils import get_output
 from .utils import FormatError, is_null, str2num, cartesian_list, pairwise_list, uniq_list, \
     get_slice, remove_parens, do_parentheses_match, find_parens, parens_aware_split, flatten_list
 from .syntax import DSC_FILE_OP
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 
 class YLine:
@@ -68,7 +72,7 @@ class Str2List(YLine):
             # Have to do it the hard way ...
             return self.split(value)
         else:
-            if not isinstance(value, (collections.Mapping, list, tuple)):
+            if not isinstance(value, (Mapping, list, tuple)):
                 return [value]
             else:
                 return value
@@ -472,7 +476,7 @@ class EntryFormatter:
         for key, value in list(cfg.items()):
             if isinstance(value, str):
                 value = value.strip().strip(',')
-            if isinstance(value, collections.Mapping):
+            if isinstance(value, Mapping):
                 self.__Transform(value, actions)
             else:
                 if not do_parentheses_match(str(value)):

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,7 +8,10 @@ import sys, os, re, yaml, itertools, collections, sympy
 from itertools import cycle, chain, islice
 from fnmatch import fnmatch
 from difflib import SequenceMatcher
-from collections.abc import Mapping, MutableMapping
+try: 
+    from collections.abc import Mapping, MutableMapping
+except ImportError:
+    from collections import Mapping, MutableMapping
 try:
     from xxhash import xxh32 as xxh
 except ImportError:


### PR DESCRIPTION
  - Python 3.10 dropped support for collections.Mapping.
  - rpy2 v3.5.11 failed to convert IntVector to numpy array.